### PR TITLE
fix import on case-sensitive filesystems

### DIFF
--- a/ParseLua.lua
+++ b/ParseLua.lua
@@ -8,7 +8,7 @@
 -- ParseLua returns an AST, internally relying on LexLua.
 --
 
-require'Strict'
+require'strict'
 
 local util = require'Util'
 local lookupify = util.lookupify


### PR DESCRIPTION
This typo caused the program to fail on non-windows systems
